### PR TITLE
Changed name of variable and added ruby 1.9.2 encoding tag

### DIFF
--- a/lib/httpauth/basic.rb
+++ b/lib/httpauth/basic.rb
@@ -105,7 +105,7 @@ module HTTPAuth
       #   RewriteEngine on
       #   RewriteRule ^admin/ - [E=X-HTTP-AUTHORIZATION:%{HTTP:Authorization}]
       def get_credentials(env)
-        d = HTTPAuth::CREDENTIAL_HEADERS.inject(false) { |d,h| env[h] || d }
+        d = HTTPAuth::CREDENTIAL_HEADERS.inject(false) { |result,h| env[h] || result }
         return unpack_authorization(d) unless !d or d.nil? or d.empty?
         [nil, nil]
       end

--- a/lib/httpauth/digest.rb
+++ b/lib/httpauth/digest.rb
@@ -381,7 +381,7 @@ module HTTPAuth
           elsif @h[:qop].include?(HTTPAuth::PREFERRED_QOP)
             @h[:qop] = HTTPAuth::PREFERRED_QOP
           else
-            qop = @h[:qop].detect { |qop| HTTPAuth::SUPPORTED_QOPS.include? qop }
+            qop = @h[:qop].detect { |qop_field| HTTPAuth::SUPPORTED_QOPS.include? qop_field }
             unless qop.nil?
               @h[:qop] = qop
             else

--- a/test/digest_scenario_test.rb
+++ b/test/digest_scenario_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 $:.unshift File.dirname(__FILE__)
 $:.unshift File.dirname(__FILE__) + '/../lib'
 

--- a/test/digest_utils_test.rb
+++ b/test/digest_utils_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 $:.unshift File.dirname(__FILE__) + '/../lib'
 
 require 'test/unit'


### PR DESCRIPTION
Made 2 small changes:
1) Changed the names of 2 variables that caused a warning when running with Ruby 1.9.2. The variables hided an outer variable and renaming it solves this.
2) Added a UTF8 tag to the tests which allows the tests to run under 1.9.2
